### PR TITLE
Catch the DirectoryNotFoundKraken raised by PR KSP-CKAN/CKAN-core#18.

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -510,6 +510,11 @@ namespace CKAN.CmdLine
                 user.RaiseMessage("One or more files failed to download, stopped.");
                 return Exit.ERROR;
             }
+            catch (DirectoryNotFoundKraken kraken)
+            {
+                user.RaiseMessage("\n{0}", kraken.Message);
+                return Exit.ERROR;
+            }
 
             return Exit.OK;
         }


### PR DESCRIPTION
Does nothing without PR KSP-CKAN/CKAN-core#18

related to KSP-CKAN/CKAN-core#3 and KSP-CKAN/CKAN-core#5
