### PR TITLE
Change the command line build.sh to call the GUI build.sh.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,8 +3,11 @@ set -x
 
 xbuild /verbosity:minimal CKAN-cmdline.sln
 
-# nunit-console --exclude=FlakyNetwork Tests/bin/Debug/Tests.dll
-# prove
+#Run the GUI build.sh
+cd ../CKAN-GUI
+sh build.sh
+cd ../CKAN-cmdline
+#prove
 
 chmod a+x ../CKAN-core/packages/ILRepack.1.25.0/tools/ILRepack.exe
 


### PR DESCRIPTION
Currently nothing calls the GUI build.sh and as such tests in the GUI repo do not get run.

@AlexanderDzhoganov @hakan42  Could instead of this PR the Jenkins build server be made to call CKAN-GUI/build.sh itself? I discussed this with nlite on IRC but I suspect we were talking past each other,