### PR TITLE
Support for searching for mods

### DIFF
--- a/Action/Search.cs
+++ b/Action/Search.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using log4net;
+
+namespace CKAN.CmdLine
+{
+    public class Search : ICommand
+    {
+        private static readonly ILog log = LogManager.GetLogger(typeof(Search));
+
+        public IUser user { get; set; }
+
+        public Search(IUser user)
+        {
+            this.user = user;
+        }
+
+        public int RunCommand(CKAN.KSP ksp, object raw_options)
+        {
+            SearchOptions options = (SearchOptions) raw_options;
+
+            // Check the input.
+            if (String.IsNullOrWhiteSpace(options.search_term))
+            {
+                user.RaiseError("No search term?");
+
+                return Exit.BADOPT;
+            }
+
+            // Convert to lowercase for easier comparison.
+            options.search_term = options.search_term.ToLower();
+
+            // Get a list of available mods.
+            List<CkanModule> available_mods = ksp.Registry.Available(ksp.Version());
+            List<CkanModule> matching_mods = new List<CkanModule>();
+
+            // Look for the search term in the list.
+            // TODO: Could use some parallism here to speed up the search.
+            foreach (CkanModule mod in available_mods)
+            {
+                // Extract the mod name, identifier. These are guaranteed to exist.
+                string mod_name = mod.name.ToLower();
+                string mod_identifier = mod.identifier.ToLower();
+
+                // Extract the description. This is an optional field and may be null.
+                string mod_description = String.Empty;
+
+                if (!String.IsNullOrEmpty(mod.description))
+                {
+                    mod_description = mod.description.ToLower();
+                }
+
+                // Look for a match in each string.
+                if (mod_name.Contains(options.search_term) || mod_identifier.Contains(options.search_term) || mod_description.Contains(options.search_term))
+                {
+                    matching_mods.Add(mod);
+                }
+            }
+
+            // Show how many matches we have.
+            user.RaiseMessage("Found " + matching_mods.Count.ToString() + " mods matching \"" + options.search_term + "\".");
+
+            // Present the results.
+            if (matching_mods.Count == 0)
+            {
+                return Exit.OK;
+            }
+
+            // Print each mod on a separate line.
+            foreach (CkanModule mod in matching_mods)
+            {
+                user.RaiseMessage(mod.identifier);
+            }
+
+            return Exit.OK;
+        }
+    }
+}
+

--- a/CKAN-cmdline.csproj
+++ b/CKAN-cmdline.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Action\Upgrade.cs" />
     <Compile Include="Action\Repo.cs" />
     <Compile Include="Action\ICommand.cs" />
+    <Compile Include="Action\Search.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Main.cs
+++ b/Main.cs
@@ -185,6 +185,10 @@ This is a bad idea and there is absolutely no good reason to do it. Please run C
                 case "show":
                     return Show((ShowOptions)cmdline.options, manager.CurrentInstance, user);
 
+                case "search":
+                    var search = new Search(user);
+                    return search.RunCommand(manager.CurrentInstance, options);
+
                 case "remove":
                     return Remove((RemoveOptions)cmdline.options, manager.CurrentInstance, user);
 

--- a/Options.cs
+++ b/Options.cs
@@ -44,7 +44,7 @@ namespace CKAN.CmdLine
         [VerbOption("gui-with-console", HelpText = "Start the CKAN GUI with the console visible")]
         public GuiOptions GuiConsoleOptions { get; set; }
 
-        [VerbOption("search", HelpText = "Search")]
+        [VerbOption("search", HelpText = "Search for mods")]
         public SearchOptions SearchOptions { get; set; }
 
         [VerbOption("upgrade", HelpText = "Upgrade an installed mod")]

--- a/Options.cs
+++ b/Options.cs
@@ -44,6 +44,9 @@ namespace CKAN.CmdLine
         [VerbOption("gui-with-console", HelpText = "Start the CKAN GUI with the console visible")]
         public GuiOptions GuiConsoleOptions { get; set; }
 
+        [VerbOption("search", HelpText = "Search")]
+        public SearchOptions SearchOptions { get; set; }
+
         [VerbOption("upgrade", HelpText = "Upgrade an installed mod")]
         public UpgradeOptions Upgrade { get; set; }
 
@@ -217,5 +220,10 @@ namespace CKAN.CmdLine
     internal class ClearCacheOptions : CommonOptions
     {
     }
-}
 
+    internal class SearchOptions : CommonOptions
+    {
+        [ValueOption(0)]
+        public string search_term { get; set; }
+    }
+}


### PR DESCRIPTION
Add support for searching for mods. Does not support wildcards at the moment.

Should solve https://github.com/KSP-CKAN/CKAN-support/issues/43.