### PR TITLE
Make the -c option accept several CKAN files

### DIFF
--- a/Action/Install.cs
+++ b/Action/Install.cs
@@ -26,6 +26,9 @@ namespace CKAN.CmdLine
                 // Oooh! We're installing from a CKAN file.
                 log.InfoFormat("Installing from CKAN file {0}", options.ckan_file);
                 options.modules.Add(LoadCkanFromFile(ksp, options.ckan_file).identifier);
+                // At times RunCommand() calls itself recursively - in this case we do
+                // not want to be doing this again, so "consume" the option
+                options.ckan_file = null;
             }
 
             if (options.modules.Count == 0)

--- a/Action/Install.cs
+++ b/Action/Install.cs
@@ -21,14 +21,17 @@ namespace CKAN.CmdLine
         {
             InstallOptions options = (InstallOptions) raw_options;
 
-            if (options.ckan_file != null)
+            if (options.ckan_files != null)
             {
                 // Oooh! We're installing from a CKAN file.
-                log.InfoFormat("Installing from CKAN file {0}", options.ckan_file);
-                options.modules.Add(LoadCkanFromFile(ksp, options.ckan_file).identifier);
+                foreach (string ckan_file in options.ckan_files)
+                {
+                    log.InfoFormat("Installing from CKAN file {0}", ckan_file);
+                    options.modules.Add(LoadCkanFromFile(ksp, ckan_file).identifier);
+                }
                 // At times RunCommand() calls itself recursively - in this case we do
                 // not want to be doing this again, so "consume" the option
-                options.ckan_file = null;
+                options.ckan_files = null;
             }
 
             if (options.modules.Count == 0)

--- a/Options.cs
+++ b/Options.cs
@@ -128,8 +128,8 @@ namespace CKAN.CmdLine
 
     internal class InstallOptions : CommonOptions
     {
-        [Option('c', "ckanfile", HelpText = "Local CKAN file to process")]
-        public string ckan_file { get; set; }
+        [OptionArray('c', "ckanfiles", HelpText = "Local CKAN files to process")]
+        public string[] ckan_files { get; set; }
 
         [Option("no-recommends", HelpText = "Do not install recommended modules")]
         public bool no_recommends { get; set; }


### PR DESCRIPTION
This enables the installation of several mods from CKAN files at once, which is very useful when testing mods with circular dependencies such as the usual core mod - config pair.

Also, fixed a small issue which made CKAN throw an inconsistent state kraken when installing a mod from a CKAN file and choosing one of several conflicting dependencies to install in the command-line prompt. The install function would then be called recursively and the mod from the CKAN file would get added to the list of mods to install again, which upset the rest of the program.

Note that the -c option now grabs everything after itself. After it is specified in the parameters, there is currently no way to give a mod name from the repository, so those must be given before:

    ckan install DockingPortAlignmentIndicator -c EnvironmentalVisualEnhancements-Config-Astronomer-Medium-Interstellar-V2.ckan EnvironmentalVisualEnhancements-HR-7-4.ckan

I would have liked just being able to specify the -c option several times (-c mod1 -c mod2...) but the options parser does not seem to allow this.