### PR TITLE
Add flag to show changes in the mod list when updating

### DIFF
--- a/Action/Update.cs
+++ b/Action/Update.cs
@@ -21,23 +21,25 @@ namespace CKAN.CmdLine
         {
             UpdateOptions options = (UpdateOptions) raw_options;
 
-            RegistryManager registry_manager = RegistryManager.Instance(ksp);
-
-            Registry registry = registry_manager.registry;
+            List<CkanModule> available_prior = null;
 
             user.RaiseMessage("Downloading updates...");
+
+            if (options.list_changes)
+            {
+                // Get a list of available modules prior to the update.
+                available_prior = ksp.Registry.Available(ksp.Version());
+            }
 
             try
             {
                 if (options.update_all)
                 {
-                    int updated = CKAN.Repo.UpdateAllRepositories(registry_manager, ksp, user);
-                    user.RaiseMessage("Updated information on {0} available modules", updated);
+                    UpdateRepository(ksp);
                 }
                 else
                 {
-                    int updated = CKAN.Repo.Update(registry_manager, ksp, user, true, options.repo);
-                    user.RaiseMessage("Updated information on {0} available modules", updated);
+                    UpdateRepository(ksp, options.repo);
                 }
             }
             catch (MissingCertificateKraken kraken)
@@ -47,8 +49,110 @@ namespace CKAN.CmdLine
                 return Exit.ERROR;
             }
 
+            if (options.list_changes)
+            {
+                PrintChanges(available_prior, ksp.Registry.Available(ksp.Version()));
+            }
+
             return Exit.OK;
+        }
+
+        /// <summary>
+        /// Locates the changes between the prior and post state of the modules..
+        /// </summary>
+        /// <param name="modules_prior">List of the available modules prior to the update.</param>
+        /// <param name="modules_post">List of the available modules after the update.</param>
+        private void PrintChanges(List<CkanModule> modules_prior, List<CkanModule> modules_post)
+        {
+            // Check for new modules.
+            List<CkanModule> added = modules_post.Where(a => !modules_prior.Select(b => b.name).Contains(a.name)).ToList();
+
+            // Check for removed modules.
+            List<CkanModule> removed = modules_prior.Where(a => !modules_post.Select(b => b.name).Contains(a.name)).ToList();
+
+            // Check for updated modules.
+            // TODO: There is most likely a better way of doing this in a single statement using LINQ.
+            List<CkanModule> updated = new List<CkanModule>();
+
+            // First, get the identifiers and version of all the mods.
+            Dictionary<string, Version> identifiers_prior = (from a in modules_prior select new {a.identifier, a.version}).ToDictionary(x => x.identifier, x => x.version);
+            Dictionary<string, Version> identifiers_post = (from b in modules_post select new {b.identifier, b.version}).ToDictionary(x => x.identifier, x => x.version);
+
+            // Compare the two lists.
+            foreach (var a in identifiers_prior)
+            {
+                // Check that the mod is still there after the update.
+                if (identifiers_post.ContainsKey(a.Key))
+                {
+                    // Check that the version has increased.
+                    if (identifiers_post[a.Key].IsGreaterThan(a.Value))
+                    {
+                        // Extract the mod information from the updated modules list.
+                        updated.Add(modules_post.Where(b => b.identifier == a.Key).First());
+                    }
+                }
+            }
+
+            // Print the changes.
+            user.RaiseMessage("Found {0} new modules, {1} removed modules and {2} updated modules.", added.Count, removed.Count, updated.Count);
+
+            if (added.Count > 0)
+            {
+                PrintModules("New modules:", added);
+            }
+
+            if (removed.Count > 0)
+            {
+                PrintModules("Removed modules:", removed);
+            }
+
+            if (updated.Count > 0)
+            {
+                PrintModules("Updated modules:", updated);
+            }
+        }
+
+        /// <summary>
+        /// Prints a message and a list of modules. Ends with a blank line.
+        /// </summary>
+        /// <param name="message">The message to print.</param>
+        /// <param name="modules">The modules to list.</param>
+        private void PrintModules(string message, List<CkanModule> modules)
+        {
+            // Check input.
+            if (message == null)
+            {
+                throw new BadCommandKraken("Message cannot be null.");
+            }
+
+            if (modules == null)
+            {
+                throw new BadCommandKraken("List of modules cannot be null.");
+            }
+
+            user.RaiseMessage(message);
+
+            foreach(CkanModule module in modules)
+            {
+                user.RaiseMessage("{0} ({1})", module.name, module.identifier);
+            }
+
+            user.RaiseMessage("");
+        }
+
+        /// <summary>
+        /// Updates the repository.
+        /// </summary>
+        /// <param name="ksp">The KSP instance to work on.</param>
+        /// <param name="repository">Repository to update. If null all repositories are used.</param>
+        private void UpdateRepository(CKAN.KSP ksp, string repository = null)
+        {
+            RegistryManager registry_manager = RegistryManager.Instance(ksp);
+
+            // Update the repository/repositories.
+            int updated = CKAN.Repo.Update(registry_manager, ksp, user, true, repository);
+
+            user.RaiseMessage("Updated information on {0} available modules", updated);
         }
     }
 }
-

--- a/Action/Update.cs
+++ b/Action/Update.cs
@@ -98,17 +98,17 @@ namespace CKAN.CmdLine
 
             if (added.Count > 0)
             {
-                PrintModules("New modules:", added);
+                PrintModules("New modules [Name (CKAN identifier)]:", added);
             }
 
             if (removed.Count > 0)
             {
-                PrintModules("Removed modules:", removed);
+                PrintModules("Removed modules [Name (CKAN identifier)]:", removed);
             }
 
             if (updated.Count > 0)
             {
-                PrintModules("Updated modules:", updated);
+                PrintModules("Updated modules [Name (CKAN identifier)]:", updated);
             }
         }
 

--- a/Options.cs
+++ b/Options.cs
@@ -203,6 +203,9 @@ namespace CKAN.CmdLine
 
         [Option("all", HelpText = "Upgrade all available updated modules")]
         public bool update_all { get; set; }
+
+        [Option("list-changes", DefaultValue = false, HelpText = "List new and removed modules")]
+        public bool list_changes { get; set; }
     }
 
     internal class RemoveOptions : CommonOptions


### PR DESCRIPTION
Running the CLI with the --list-changes flag when updating the repository will now print a list of:
* Added mods
* Removed mods
* Updated mods

Both the name and the CKAN identifier is printed for easy installation/removal afterwards.

Closes #42.