### PR TITLE
Adds regular expressions support in Remove

### DIFF
--- a/Options.cs
+++ b/Options.cs
@@ -210,6 +210,9 @@ namespace CKAN.CmdLine
 
     internal class RemoveOptions : CommonOptions
     {
+        [Option("re", HelpText = "Parse arguments as regular expressions")]
+        public bool regex { get; set; }
+
         [ValueList(typeof(List<string>))]
         public List<string> modules { get; set; }
     }


### PR DESCRIPTION
Makes it possible to use regular expressions to select mods to remove.

Example usage is:

    ckan remove --re Astronomers.*  "(K|k)\w+"

A module is selected if it matches one or more regular expression in the arguments list.

Depends on KSP-CKAN/CKAN-core#84