### PR TITLE
Bundle curlsharp library in build.

### DIFF
--- a/CKAN-cmdline.csproj
+++ b/CKAN-cmdline.csproj
@@ -17,24 +17,23 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CKAN, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\CKAN-GUI\bin\Debug\CKAN.dll</HintPath>
-    </Reference>
-    <Reference Include="CommandLine, Version=1.9.71.2, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\CKAN-core\packages\CommandLineParser.1.9.71\lib\net40\CommandLine.dll</HintPath>
-    </Reference>
-    <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\CKAN-core\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\CKAN-core\packages\Newtonsoft.Json.6.0.5\lib\net40\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Transactions" />
+    <Reference Include="CKAN">
+      <HintPath>..\CKAN-GUI\bin\Debug\CKAN.dll</HintPath>
+    </Reference>
+    <Reference Include="CommandLine">
+      <HintPath>..\CKAN-core\packages\CommandLineParser.1.9.71\lib\net40\CommandLine.dll</HintPath>
+    </Reference>
+    <Reference Include="log4net">
+      <HintPath>..\CKAN-core\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\CKAN-core\packages\Newtonsoft.Json.6.0.5\lib\net40\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="CurlSharp">
+      <HintPath>..\CKAN-core\packages\curlsharp-v0.5.1-2-gd2d5699\CurlSharp.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ConsoleUser.cs" />

--- a/build.sh
+++ b/build.sh
@@ -23,5 +23,5 @@ mono ../CKAN-core/packages/ILRepack.1.25.0/tools/ILRepack.exe \
 	bin/Debug/log4net.dll \
 	bin/Debug/Newtonsoft.Json.dll \
 	bin/Debug/INIFileParser.dll \
-        ../CKAN-core/packages/curlsharp-v0.5.1-2-gd2d5699/CurlSharp.dll
+        bin/Debug/CurlSharp.dll
 

--- a/build.sh
+++ b/build.sh
@@ -22,5 +22,6 @@ mono ../CKAN-core/packages/ILRepack.1.25.0/tools/ILRepack.exe \
 	bin/Debug/ICSharpCode.SharpZipLib.dll \
 	bin/Debug/log4net.dll \
 	bin/Debug/Newtonsoft.Json.dll \
-	bin/Debug/INIFileParser.dll
+	bin/Debug/INIFileParser.dll \
+        ../CKAN-core/packages/curlsharp-v0.5.1-2-gd2d5699/CurlSharp.dll
 


### PR DESCRIPTION
This depends upon KSP-CKAN/CKAN-core#87, and simply adds Curlsharp to the repack list so users don't need to download it separately.

For KSP-CKAN/CKAN-support#107.