### PR TITLE
Escape Uri strings to allow clicking them in consoles.

### DIFF
--- a/Action/Show.cs
+++ b/Action/Show.cs
@@ -194,13 +194,13 @@ namespace CKAN.CmdLine
             if (module.resources != null)
             {
                 if (module.resources.bugtracker != null)
-                    user.RaiseMessage("- bugtracker: {0}", module.resources.bugtracker.ToString());
+                    user.RaiseMessage("- bugtracker: {0}", Uri.EscapeUriString(module.resources.bugtracker.ToString()));
                 if (module.resources.homepage != null)
-                    user.RaiseMessage("- homepage: {0}", module.resources.homepage.ToString());
+                    user.RaiseMessage("- homepage: {0}", Uri.EscapeUriString(module.resources.homepage.ToString()));
                 if (module.resources.kerbalstuff != null)
-                    user.RaiseMessage("- kerbalstuff: {0}", module.resources.kerbalstuff.ToString());
+                    user.RaiseMessage("- kerbalstuff: {0}", Uri.EscapeUriString(module.resources.kerbalstuff.ToString()));
                 if (module.resources.repository != null)
-                    user.RaiseMessage("- repository: {0}", module.resources.repository.ToString());
+                    user.RaiseMessage("- repository: {0}", Uri.EscapeUriString(module.resources.repository.ToString()));
             }
 
             return Exit.OK;


### PR DESCRIPTION
It was reported in https://github.com/KSP-CKAN/CKAN/issues/826 that Uri strings are not escaped properly. This should hopefully resolve this, by escaping all the strings in the resource section of the show command. @pjf Found some issues with the mono implementation of the string escape function, but from what I can tell this works under mono for the case reported.

Closes https://github.com/KSP-CKAN/CKAN/issues/826.