### PR TITLE
Print the filename of the file if it were to be downloaded.

### DIFF
--- a/Action/Show.cs
+++ b/Action/Show.cs
@@ -203,6 +203,12 @@ namespace CKAN.CmdLine
                     user.RaiseMessage("- repository: {0}", module.resources.repository.ToString());
             }
 
+            // Compute the CKAN filename.
+            string file_uri_hash = NetFileCache.CreateURLHash(module.download);
+            string file_name = CkanModule.StandardName(module.identifier, module.version);
+
+            user.RaiseMessage("\nFilename: {0}", file_uri_hash + "-" + file_name);
+
             return Exit.OK;
         }
 


### PR DESCRIPTION
Will print the filename of a module if it were to be downloaded, so people with connectivity issues can do a manual download and put the file in there themselves. Relevant for https://github.com/KSP-CKAN/CKAN-core/issues/101. Depends on https://github.com/KSP-CKAN/CKAN-core/pull/111.