### PR TITLE
Default choice for Yes/No questions to Yes

### DIFF
--- a/ConsoleUser.cs
+++ b/ConsoleUser.cs
@@ -29,7 +29,7 @@ namespace CKAN.CmdLine
                 return true;
             }
 
-            Console.Write("{0} [Y/N] ", message);
+            Console.Write("{0} [Y/n] ", message);
             while (true)
             {
                 var input = Console.In.ReadLine();
@@ -49,6 +49,11 @@ namespace CKAN.CmdLine
                 if (input.Equals("n") || input.Equals("no"))
                 {
                     return false;
+                }
+                if (input.Equals(string.Empty))
+                {
+                    // User pressed enter without any text, assuming default choice.
+                    return true;
                 }
                 Console.Write("Invaild input. Please enter yes or no");
             }

--- a/ConsoleUser.cs
+++ b/ConsoleUser.cs
@@ -55,7 +55,8 @@ namespace CKAN.CmdLine
                     // User pressed enter without any text, assuming default choice.
                     return true;
                 }
-                Console.Write("Invaild input. Please enter yes or no");
+
+                Console.Write("Invalid input. Please enter yes or no");
             }
         }
 


### PR DESCRIPTION
In other version control schemes I am used to pressing enter in a dialog will do the action I've requested by default. This changes the behavior of the CKAN CLI to this, and changes the capitalization in the question to support this (The default choice is the capitalized letter).