### PR TITLE
Implement UpdateAllRepositories

### DIFF
--- a/Action/Update.cs
+++ b/Action/Update.cs
@@ -28,6 +28,9 @@ namespace CKAN.CmdLine
             // If no repository is selected, select all.
             if (options.repo == null)
             {
+                // Get a list of available modules prior to the update.
+                available_prior = ksp.Registry.Available(ksp.Version());
+
                 options.update_all = true;
             }
 

--- a/Action/Update.cs
+++ b/Action/Update.cs
@@ -25,10 +25,10 @@ namespace CKAN.CmdLine
 
             user.RaiseMessage("Downloading updates...");
 
-            if (options.list_changes)
+            // If no repository is selected, select all.
+            if (options.repo == null)
             {
-                // Get a list of available modules prior to the update.
-                available_prior = ksp.Registry.Available(ksp.Version());
+                options.update_all = true;
             }
 
             try
@@ -149,8 +149,18 @@ namespace CKAN.CmdLine
         {
             RegistryManager registry_manager = RegistryManager.Instance(ksp);
 
-            // Update the repository/repositories.
-            int updated = CKAN.Repo.Update(registry_manager, ksp, user, true, repository);
+            int updated = 0;
+
+            if (repository == null)
+            {
+                // Update the repository/repositories.
+                updated = CKAN.Repo.UpdateAllRepositories(registry_manager, ksp, user);
+            }
+            else
+            {
+                // Update the repository/repositories.
+                updated = CKAN.Repo.Update(registry_manager, ksp, user, true, repository);
+            }
 
             user.RaiseMessage("Updated information on {0} available modules", updated);
         }


### PR DESCRIPTION
Changed UpdateRepository to call UpdateAllRepositories in the core when appropriate. This fixes an error where "ckan update" would pull from the default repository instead of all the repositories as requested by the CLI.