### PR TITLE
Add compare command

### DIFF
--- a/Action/Compare.cs
+++ b/Action/Compare.cs
@@ -1,0 +1,17 @@
+﻿namespace CKAN.CmdLine
+{
+    public class Compare : ICommand
+    {
+        public int RunCommand(CKAN.KSP ksp, object rawOptions)
+        {
+            var options = (CompareOptions)rawOptions;
+
+            var leftVersion = new Version(options.Left);
+            var rightVersion = new Version(options.Right);
+
+            ksp.User.RaiseMessage(leftVersion.CompareTo(rightVersion).ToString());
+
+            return 0;
+        }
+    }
+}

--- a/CKAN-cmdline.csproj
+++ b/CKAN-cmdline.csproj
@@ -36,6 +36,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Action\Compare.cs" />
     <Compile Include="ConsoleUser.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Main.cs" />

--- a/Main.cs
+++ b/Main.cs
@@ -210,6 +210,9 @@ This is a bad idea and there is absolutely no good reason to do it. Please run C
                     var repo = new Repo (manager, user);
                     return repo.RunSubCommand((SubCommandOptions) cmdline.options);
 
+                case "compare":
+                    return (new Compare()).RunCommand(manager.CurrentInstance, cmdline.options);
+
                 default:
                     user.RaiseMessage("Unknown command, try --help");
                     return Exit.BADOPT;

--- a/Options.cs
+++ b/Options.cs
@@ -83,6 +83,9 @@ namespace CKAN.CmdLine
         [VerbOption("ksp", HelpText = "Manage KSP installs")]
         public SubCommandOptions Repo { get; set; }
 
+        [VerbOption("compare", HelpText = "Compare version strings")]
+        public CompareOptions Compare { get; set; }
+
         [VerbOption("version", HelpText = "Show the version of the CKAN client being used.")]
         public VersionOptions Version { get; set; }
     }
@@ -231,5 +234,14 @@ namespace CKAN.CmdLine
     {
         [ValueOption(0)]
         public string search_term { get; set; }
+    }
+
+    internal class CompareOptions : CommonOptions
+    {
+        [ValueOption(0)]
+        public string Left { get; set; }
+
+        [ValueOption(1)]
+        public string Right { get; set; }
     }
 }


### PR DESCRIPTION
Adds a `compare` command to the CKAN client in the vein of Arch Linux's [`vercmp`](https://www.archlinux.org/pacman/vercmp.8.html) utility.

It takes two version strings as arguments and then prints the value of the `CompareTo` method on `Version`. Useful for checking how CKAN will compare non-trivial version identifiers.

Examples:

```
> ckan compare 1.0 1.1
-1
```

```
> ckan compare v0.15.1_Fanno v0.15.0_Euler
1
```

```
> ckan compare 1:1.0 2.0
1
```

```
> ckan compare foo foo
0
```

```
> ckan compare 1 v1
-118
```
